### PR TITLE
[FIX] SVG image crash

### DIFF
--- a/src/Indiko.Maui.Controls.Markdown/Indiko.Maui.Controls.Markdown.csproj
+++ b/src/Indiko.Maui.Controls.Markdown/Indiko.Maui.Controls.Markdown.csproj
@@ -38,7 +38,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>1.3.13-flowfix.2</Version>
+		<Version>1.3.13-flowfix.3</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Indiko.Maui.Controls.Markdown/MarkdownView.cs
+++ b/src/Indiko.Maui.Controls.Markdown/MarkdownView.cs
@@ -1657,7 +1657,8 @@ public sealed class MarkdownView : ContentView
                                 image.Encode(SKEncodedImageFormat.Png, 100).SaveTo(imageStream);
                                 imageStream.Position = 0;
                                 imageSource = ImageSource.FromStream(() => imageStream);
-                                if (imageUrl != null) _imageCache[imageUrl] = imageSource;
+                                
+                                // Don't cache svg images. It crashes on Android and doesn't work on iOS either.
 
                                 xmlDocument = null;
                                 xmlReader.Dispose();


### PR DESCRIPTION
Fixed a problem with cached SVG images that caused a crash on Android and the images to disappear on iOS.

You can reproduce the problem on the markdown debug page in the Halo app if you modify the markdown source. This can cause the app to crash on Android or the svg images at the bottom of the page to disappear on iOS.

The crash was caused by the cached images. In the future we should figure out why it crashed, but for now the workaround is just to disable the cache for SVG images. (It seems to work well for PNG images).